### PR TITLE
fix: bundle install(add nokogiri to Gemfile)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,3 +47,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data'
 
+gem 'nokogiri', '1.10.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,7 @@ DEPENDENCIES
   factory_bot_rails
   image_processing (~> 1.2)
   listen (>= 3.0.5, < 3.2)
+  nokogiri (= 1.10.9)
   puma (~> 3.12.4)
   rack-cors
   rails (~> 6.0.0)


### PR DESCRIPTION
 `$ bundle install` が以下のエラーで通らなかったためnokogiriを追加
```
An error occurred while installing nokogiri (1.10.9), and Bundler cannot continue.
Make sure that `gem install nokogiri -v '1.10.9' --source 'https://rubygems.org/'` succeeds before
bundling.
```